### PR TITLE
Fix AsyncBytes buffer finish

### DIFF
--- a/Sources/Subprocess/Subprocess+AsyncBytes.swift
+++ b/Sources/Subprocess/Subprocess+AsyncBytes.swift
@@ -49,7 +49,7 @@ extension Subprocess {
                     self.buffer = try await self.fileDescriptor.read(
                         upToLength: Subprocess.readBufferSize)
                     self.currentPosition = 0
-                    if self.buffer.count < Subprocess.readBufferSize {
+                    if self.buffer.isEmpty {
                         self.finished = true
                     }
                 } catch {


### PR DESCRIPTION
Fixes: https://github.com/iCharlesHu/swift-experimental-subprocess/issues/4

Some processes seem to output data in bursts (not sure what the correct term is), meaning that they might not return the full requested amount for stdout and should only be considered "finished" when they return nothing. Right now, Subprocess considers the stream finished if the returned data is smaller than the requested data, resulting in the process being considered finished too early and the remaining output being lost.

The fix is to only consider the stream finished when the returned data is empty