### PR TITLE
Add DocC to preview the latest API from the code

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Subprocess]

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,11 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-system",
             from: "1.0.0"
-        )
-
+        ),
+        .package(
+            url: "https://github.com/apple/swift-docc-plugin",
+            from: "1.4.3"
+        ),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ Let's break down the example above:
 
 ## Detailed Design
 
+The latest API documentation can be viewed by running the following command:
+
+```
+swift package --disable-sandbox preview-documentation --target Subprocess
+```
+
 ### `Subprocess` and `SubprocessFoundation` Modules
 
 Within this package, we propose two modules: `Subprocess` and `SubprocessFoundation`. `Subprocess` serves as the “core” module, relying solely on `swift-system` and the standard library. `SubprocessFoundation` extends `Subprocess` by depending on and incorporating types from `Foundation`.


### PR DESCRIPTION
There are some small discrepancies between the README.md and the code. Add DocC documentation so that people can browse the latest API without having to open an IDE and manually inspect the code, or rely on the README.