### PR TITLE
Expand teardown to work on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,13 @@ dep.append(
 )
 #endif
 
+// Enable SubprocessFoundation by default
+var defaultTraits: Set<String> = ["SubprocessFoundation"]
+#if compiler(>=6.2)
+// Enable SubprocessSpan when Span is available
+defaultTraits.insert("SubprocessSpan")
+#endif
+
 let package = Package(
     name: "Subprocess",
     platforms: [.macOS("15.0"), .iOS("18.0"), .tvOS("18.0"), .watchOS("11.0")],
@@ -35,10 +42,7 @@ let package = Package(
         "SubprocessFoundation",
         "SubprocessSpan",
         .default(
-            enabledTraits: [
-                "SubprocessFoundation",
-                "SubprocessSpan"
-            ]
+            enabledTraits: defaultTraits
         )
     ],
     dependencies: dep,

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 * Proposal: [SF-0007](0007-swift-subprocess.md)
 * Authors: [Charles Hu](https://github.com/iCharlesHu)
 * Review Manager: [Tina Liu](https://github.com/itingliu)
-* Status: **2nd Review, Active: Dec 12, 2024...Dec 19, 2024**
+* Status: **3nd Review, Active: Feb 24, 2025...March 03, 2025**
 * Bugs: [rdar://118127512](rdar://118127512), [apple/swift-foundation#309](https://github.com/apple/swift-foundation/issues/309)
+* Review: [Pitch](https://forums.swift.org/t/pitch-swift-subprocess/69805/65), [1st review](https://forums.swift.org/t/review-sf-0007-introducing-swift-subprocess/70337), [2nd review](https://forums.swift.org/t/review-2nd-sf-0007-subprocess/76547)
 
 
 ## Revision History
@@ -227,8 +228,8 @@ For Swift 6.0 and earlier versions, `SubprocessFoundation` is essentially always
 We propose several `run()` functions that allow developers to asynchronously execute a subprocess.
 
 ```swift
-/// Run a executable with given parameters and a custom closure
-/// to manage the running subprocess' lifetime and its IOs.
+/// Run a executable with given parameters asynchrously and returns
+/// a `CollectedResult` containing the output of the child process.
 /// - Parameters:
 ///   - executable: The executable to run.
 ///   - arguments: The arguments to pass to the executable.
@@ -239,7 +240,6 @@ We propose several `run()` functions that allow developers to asynchronously exe
 ///   - input: The input to send to the executable.
 ///   - output: The method to use for redirecting the standard output.
 ///   - error: The method to use for redirecting the standard error.
-///   - body: The custom execution body to manually control the running process
 /// - Returns a CollectedResult containing the result of the run.
 #if SubprocessSpan
 @available(SubprocessSpan, *)
@@ -259,8 +259,8 @@ public func run<
     error: Error = .discarded
 ) async throws -> CollectedResult<Output, Error>
 
-/// Run a executable with given parameters and a custom closure
-/// to manage the running subprocess' lifetime and its IOs.
+/// Run a executable with given parameters asynchrously and returns
+/// a `CollectedResult` containing the output of the child process.
 /// - Parameters:
 ///   - executable: The executable to run.
 ///   - arguments: The arguments to pass to the executable.
@@ -268,10 +268,9 @@ public func run<
 ///   - workingDirectory: The working directory in which to run the executable.
 ///   - platformOptions: The platform specific options to use
 ///     when running the executable.
-///   - input: span to write to subprocess' standard input.
+///   - input: The input to send to the executable.
 ///   - output: The method to use for redirecting the standard output.
 ///   - error: The method to use for redirecting the standard error.
-///   - body: The custom execution body to manually control the running process
 /// - Returns a CollectedResult containing the result of the run.
 #if SubprocessSpan
 @available(SubprocessSpan, *)
@@ -353,8 +352,8 @@ public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
     body: ((Execution<Output, Error>, StandardInputWriter) async throws -> Result)
 ) async throws -> ExecutionResult<Result> where Output.OutputType == Void, Error.OutputType == Void
 
-/// Run a executable with given parameters and a custom closure
-/// to manage the running subprocess' lifetime and its IOs.
+/// Run a `Configuration` asynchrously and returns
+/// a `CollectedResult` containing the output of the child process.
 /// - Parameters:
 ///   - configuration: The `Subprocess` configuration to run.
 ///   - input: The input to send to the executable.
@@ -544,8 +543,6 @@ extension Execution where Error == SequenceOutput {
 public struct ProcessIdentifier: Sendable, Hashable, Codable {
     /// Windows specifc process identifier value
     public let value: DWORD
-    /// Windows specific thread identifier associated with process
-    public let threadID: DWORD
 }
 #else
 /// A platform independent identifier for a Subprocess.

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -188,8 +188,8 @@ public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
 
 // MARK: - Configuration Based
 
-/// Run a executable with given parameters and a custom closure
-/// to manage the running subprocess' lifetime and its IOs.
+/// Run a `Configuration` asynchrously and returns
+/// a `CollectedResult` containing the output of the child process.
 /// - Parameters:
 ///   - configuration: The `Subprocess` configuration to run.
 ///   - input: The input to send to the executable.

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -365,7 +365,6 @@ extension Configuration {
             return
         }
 
-        var exitError: Swift.Error? = nil
         // Attempt to teardown the subprocess
         if attemptToTerminateSubProcess {
             await execution.teardown(
@@ -411,10 +410,6 @@ extension Configuration {
 
         if let errorError = errorError {
             throw errorError
-        }
-
-        if let exitError = exitError {
-            throw exitError
         }
     }
 

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -368,13 +368,9 @@ extension Configuration {
         var exitError: Swift.Error? = nil
         // Attempt to teardown the subprocess
         if attemptToTerminateSubProcess {
-#if os(Windows)
-            exitError = execution.tryTerminate()
-#else
             await execution.teardown(
                 using: self.platformOptions.teardownSequence
             )
-#endif
         }
 
         var inputError: Swift.Error?

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -102,7 +102,7 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
         case .failedToWriteToSubprocess:
             return "Failed to write bytes to the child process."
         case .failedToMonitorProcess:
-            return "Failed to monitor the state of child process."
+            return "Failed to monitor the state of child process with underlying error: \(self.underlyingError!)"
         case .failedToSendSignal(let signal):
             return "Failed to send signal \(signal) to the child process."
         case .failedToTerminate:

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -370,6 +370,11 @@ public struct PlatformOptions: Sendable {
     /// The process identifier of the new process group
     /// is the same as the process identifier.
     public var createProcessGroup: Bool = false
+    /// An ordered list of steps in order to tear down the child
+    /// process in case the parent task is cancelled before
+    /// the child proces terminates.
+    /// Always ends in forcefully terminate at the end.
+    public var teardownSequence: [TeardownStep] = []
     /// A closure to configure platform-specific
     /// spawning constructs. This closure enables direct
     /// configuration or override of underlying platform-specific

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -146,8 +146,7 @@ extension Configuration {
             )
         }
         let pid = ProcessIdentifier(
-            value: processInfo.dwProcessId,
-            threadID: processInfo.dwThreadId
+            value: processInfo.dwProcessId
         )
         return Execution(
             processIdentifier: pid,
@@ -263,8 +262,7 @@ extension Configuration {
             )
         }
         let pid = ProcessIdentifier(
-            value: processInfo.dwProcessId,
-            threadID: processInfo.dwThreadId
+            value: processInfo.dwProcessId
         )
         return Execution(
             processIdentifier: pid,
@@ -720,21 +718,15 @@ extension Environment {
 public struct ProcessIdentifier: Sendable, Hashable, Codable {
     /// Windows specifc process identifier value
     public let value: DWORD
-    /// Windows specific thread identifier associated with process
-    public let threadID: DWORD
 
-    internal init(
-        value: DWORD,
-        threadID: DWORD
-    ) {
+    internal init(value: DWORD) {
         self.value = value
-        self.threadID = threadID
     }
 }
 
 extension ProcessIdentifier: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
-        return "(processID: \(self.value), threadID: \(self.threadID))"
+        return "(processID: \(self.value))"
     }
 
     public var debugDescription: String {

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -26,7 +26,7 @@ import _SubprocessCShims
 
 
 /// A step in the graceful shutdown teardown sequence.
-/// It consists of a signal to send to the child process and the
+/// It consists of an action to perform on the child process and the
 /// duration allowed for the child process to exit before proceeding
 /// to the next step.
 public struct TeardownStep: Sendable, Hashable {
@@ -56,6 +56,14 @@ public struct TeardownStep: Sendable, Hashable {
     }
 #endif // !os(Windows)
 
+    /// Attempt to perform a graceful shutdown and allows
+    /// `alloweDurationToNextStep` for the process to exit
+    /// before proceeding to the next step:
+    /// - On Unix: send `SIGTERM`
+    /// - On Windows:
+    ///   1. Attempt to send `VM_CLOSE` if the child process is a GUI process;
+    ///   2. Attempt to send `CTRL_C_EVENT` to console;
+    ///   3. Attempt to send `CTRL_BREAK_EVENT` to process group.
     public static func gracefulShutDown(
         alloweDurationToNextStep: Duration
     ) -> Self {

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -85,23 +85,7 @@ extension Execution {
     /// - Parameter sequence: The  steps to perform.
     public func teardown(using sequence: some Sequence<TeardownStep> & Sendable) async {
         await withUncancelledTask {
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    await self.runTeardownSequence(sequence)
-                }
-                group.addTask {
-                    do {
-                        _ = try await monitorProcessTermination(
-                            forProcessWithIdentifier: self.processIdentifier
-                        )
-                    } catch {
-                        // noop
-                    }
-                }
-                // As soon as the child process exits, cancel the teardown task
-                await group.next()
-                group.cancelAll()
-            }
+            await self.runTeardownSequence(sequence)
         }
     }
 }

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -73,4 +73,11 @@ int _shims_snprintf(
 
 #endif // !TARGET_OS_WINDOWS
 
+#if TARGET_OS_WINDOWS
+#include <windows.h>
+
+BOOL _subprocess_windows_send_vm_close(DWORD pid);
+
+#endif
+
 #endif /* process_shims_h */


### PR DESCRIPTION
Introduce a cross platform `TeardownStep.gracefulShutDown(alloweDurationToNextStep:)` and add Windows support:
- On Unix: send `SIGTERM`
- On Windows:
  1. Attempt to send `VM_CLOSE` if the child process is a GUI process;
  2. Attempt to send `CTRL_C_EVENT` to console;
  3. Attempt to send `CTRL_BREAK_EVENT` to process group.