### PR TITLE
Fix typo in `TeardownStep.gracefulShutDown` parameter

### DIFF
--- a/Proposal.md
+++ b/Proposal.md
@@ -103,7 +103,7 @@
     - Revise `InputProtocol` and `OutputProtocol` to not expose `FileDescriptor` directly
     - Added `SubprocessSpan` trait
     - Removed the opaque `Pipe`
-    - Introduce a cross platform TeardownStep.gracefulShutDown(alloweDurationToNextStep:) and add Windows support
+    - Introduce a cross platform TeardownStep.gracefulShutDown(allowedDurationToNextStep:) and add Windows support
 
 ## Introduction
 
@@ -653,7 +653,7 @@ public struct TeardownStep: Sendable, Hashable {
 #endif
 
     /// Attempt to perform a graceful shutdown and allows
-    /// `alloweDurationToNextStep` for the process to exit
+    /// `allowedDurationToNextStep` for the process to exit
     /// before proceeding to the next step:
     /// - On Unix: send `SIGTERM`
     /// - On Windows:
@@ -661,7 +661,7 @@ public struct TeardownStep: Sendable, Hashable {
     ///   2. Attempt to send `CTRL_C_EVENT` to console;
     ///   3. Attempt to send `CTRL_BREAK_EVENT` to process group.
     public static func gracefulShutDown(
-        alloweDurationToNextStep: Duration
+        allowedDurationToNextStep: Duration
     ) -> Self
 }
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ let result = try await run(
             await execution.teardown(
                 using: [
                     .gracefulShutDown(
-                        alloweDurationToNextStep: .seconds(0.5)
+                        allowedDurationToNextStep: .seconds(0.5)
                     )
                 ]
             )


### PR DESCRIPTION
Hi @iCharlesHu. Thanks for your work on SF-0007 and this library. While trying it out in my own project, I noticed a typo in the parameter name for `TeardownStep.gracefulShutDown` ( `alloweDurationToNextStep` instead of `allowedDurationToNextStep`). So I thought I'd open a PR to fix that.