### PR TITLE
Fix swift 6.0.3 Linux build

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -40,7 +40,6 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
-                .enableExperimentalFeature("NonescapableTypes"),
                 .define("SubprocessFoundation"),
                 availabilityMacro,
             ]


### PR DESCRIPTION
This one seems like a compiler bug to me. However, we can work around it by removing the unnecessary "NonescapableTypes" feature from the 6.0 package file).

Resolves: https://github.com/iCharlesHu/Subprocess/issues/53