### PR TITLE
Address TOCTOU issues in Subprocess

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -144,184 +144,220 @@ extension Configuration {
         error: Error,
         errorPipe: CreatedPipe
     ) throws -> Execution<Output, Error> {
-        let (
-            executablePath,
-            env, argv,
-            intendedWorkingDir,
-            uidPtr, gidPtr, supplementaryGroups
-        ) = try self.preSpawn()
-        defer {
-            for ptr in env { ptr?.deallocate() }
-            for ptr in argv { ptr?.deallocate() }
-            uidPtr?.deallocate()
-            gidPtr?.deallocate()
-        }
 
-        // Setup file actions and spawn attributes
-        var fileActions: posix_spawn_file_actions_t? = nil
-        var spawnAttributes: posix_spawnattr_t? = nil
-        // Setup stdin, stdout, and stderr
-        posix_spawn_file_actions_init(&fileActions)
-        defer {
-            posix_spawn_file_actions_destroy(&fileActions)
-        }
-        // Input
-        var result: Int32 = -1
-        if let inputRead = inputPipe.readFileDescriptor {
-            result = posix_spawn_file_actions_adddup2(&fileActions, inputRead.wrapped.rawValue, 0)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
+        // Instead of checking if every possible executable path
+        // is valid, spawn each directly and catch ENOENT
+        let possiblePaths = self.executable.possibleExecutablePaths(
+            withPathValue: self.environment.pathValue()
+        )
+        for possibleExecutablePath in possiblePaths {
+            var pid: pid_t = 0
+            let (
+                env,
+                uidPtr,
+                gidPtr,
+                supplementaryGroups
+            ) = try self.preSpawn()
+            defer {
+                for ptr in env { ptr?.deallocate() }
+                uidPtr?.deallocate()
+                gidPtr?.deallocate()
             }
-        }
-        if let inputWrite = inputPipe.writeFileDescriptor {
-            // Close parent side
-            result = posix_spawn_file_actions_addclose(&fileActions, inputWrite.wrapped.rawValue)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
+            // Setup Arguments
+            let argv: [UnsafeMutablePointer<CChar>?] = self.arguments.createArgs(
+                withExecutablePath: possibleExecutablePath
+            )
+            defer {
+                for ptr in argv { ptr?.deallocate() }
             }
-        }
-        // Output
-        if let outputWrite = outputPipe.writeFileDescriptor {
-            result = posix_spawn_file_actions_adddup2(&fileActions, outputWrite.wrapped.rawValue, 1)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
-            }
-        }
-        if let outputRead = outputPipe.readFileDescriptor {
-            // Close parent side
-            result = posix_spawn_file_actions_addclose(&fileActions, outputRead.wrapped.rawValue)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
-            }
-        }
-        // Error
-        if let errorWrite = errorPipe.writeFileDescriptor {
-            result = posix_spawn_file_actions_adddup2(&fileActions, errorWrite.wrapped.rawValue, 2)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
-            }
-        }
-        if let errorRead = errorPipe.readFileDescriptor {
-            // Close parent side
-            result = posix_spawn_file_actions_addclose(&fileActions, errorRead.wrapped.rawValue)
-            guard result == 0 else {
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: result)
-                )
-            }
-        }
-        // Setup spawnAttributes
-        posix_spawnattr_init(&spawnAttributes)
-        defer {
-            posix_spawnattr_destroy(&spawnAttributes)
-        }
-        var noSignals = sigset_t()
-        var allSignals = sigset_t()
-        sigemptyset(&noSignals)
-        sigfillset(&allSignals)
-        posix_spawnattr_setsigmask(&spawnAttributes, &noSignals)
-        posix_spawnattr_setsigdefault(&spawnAttributes, &allSignals)
-        // Configure spawnattr
-        var spawnAttributeError: Int32 = 0
-        var flags: Int32 = POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
-        if let pgid = self.platformOptions.processGroupID {
-            flags |= POSIX_SPAWN_SETPGROUP
-            spawnAttributeError = posix_spawnattr_setpgroup(&spawnAttributes, pid_t(pgid))
-        }
-        spawnAttributeError = posix_spawnattr_setflags(&spawnAttributes, Int16(flags))
-        // Set QualityOfService
-        // spanattr_qos seems to only accept `QOS_CLASS_UTILITY` or `QOS_CLASS_BACKGROUND`
-        // and returns an error of `EINVAL` if anything else is provided
-        if spawnAttributeError == 0 && self.platformOptions.qualityOfService == .utility {
-            spawnAttributeError = posix_spawnattr_set_qos_class_np(&spawnAttributes, QOS_CLASS_UTILITY)
-        } else if spawnAttributeError == 0 && self.platformOptions.qualityOfService == .background {
-            spawnAttributeError = posix_spawnattr_set_qos_class_np(&spawnAttributes, QOS_CLASS_BACKGROUND)
-        }
 
-        // Setup cwd
-        var chdirError: Int32 = 0
-        if intendedWorkingDir != .currentWorkingDirectory {
-            chdirError = intendedWorkingDir.withPlatformString { workDir in
+            // Setup file actions and spawn attributes
+            var fileActions: posix_spawn_file_actions_t? = nil
+            var spawnAttributes: posix_spawnattr_t? = nil
+            // Setup stdin, stdout, and stderr
+            posix_spawn_file_actions_init(&fileActions)
+            defer {
+                posix_spawn_file_actions_destroy(&fileActions)
+            }
+            // Input
+            var result: Int32 = -1
+            if let inputRead = inputPipe.readFileDescriptor {
+                result = posix_spawn_file_actions_adddup2(&fileActions, inputRead.wrapped.rawValue, 0)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            if let inputWrite = inputPipe.writeFileDescriptor {
+                // Close parent side
+                result = posix_spawn_file_actions_addclose(&fileActions, inputWrite.wrapped.rawValue)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            // Output
+            if let outputWrite = outputPipe.writeFileDescriptor {
+                result = posix_spawn_file_actions_adddup2(&fileActions, outputWrite.wrapped.rawValue, 1)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            if let outputRead = outputPipe.readFileDescriptor {
+                // Close parent side
+                result = posix_spawn_file_actions_addclose(&fileActions, outputRead.wrapped.rawValue)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            // Error
+            if let errorWrite = errorPipe.writeFileDescriptor {
+                result = posix_spawn_file_actions_adddup2(&fileActions, errorWrite.wrapped.rawValue, 2)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            if let errorRead = errorPipe.readFileDescriptor {
+                // Close parent side
+                result = posix_spawn_file_actions_addclose(&fileActions, errorRead.wrapped.rawValue)
+                guard result == 0 else {
+                    try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: result)
+                    )
+                }
+            }
+            // Setup spawnAttributes
+            posix_spawnattr_init(&spawnAttributes)
+            defer {
+                posix_spawnattr_destroy(&spawnAttributes)
+            }
+            var noSignals = sigset_t()
+            var allSignals = sigset_t()
+            sigemptyset(&noSignals)
+            sigfillset(&allSignals)
+            posix_spawnattr_setsigmask(&spawnAttributes, &noSignals)
+            posix_spawnattr_setsigdefault(&spawnAttributes, &allSignals)
+            // Configure spawnattr
+            var spawnAttributeError: Int32 = 0
+            var flags: Int32 = POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
+            if let pgid = self.platformOptions.processGroupID {
+                flags |= POSIX_SPAWN_SETPGROUP
+                spawnAttributeError = posix_spawnattr_setpgroup(&spawnAttributes, pid_t(pgid))
+            }
+            spawnAttributeError = posix_spawnattr_setflags(&spawnAttributes, Int16(flags))
+            // Set QualityOfService
+            // spanattr_qos seems to only accept `QOS_CLASS_UTILITY` or `QOS_CLASS_BACKGROUND`
+            // and returns an error of `EINVAL` if anything else is provided
+            if spawnAttributeError == 0 && self.platformOptions.qualityOfService == .utility {
+                spawnAttributeError = posix_spawnattr_set_qos_class_np(&spawnAttributes, QOS_CLASS_UTILITY)
+            } else if spawnAttributeError == 0 && self.platformOptions.qualityOfService == .background {
+                spawnAttributeError = posix_spawnattr_set_qos_class_np(&spawnAttributes, QOS_CLASS_BACKGROUND)
+            }
+
+            // Setup cwd
+            let intendedWorkingDir = self.workingDirectory.string
+            let chdirError: Int32 = intendedWorkingDir.withPlatformString { workDir in
                 return posix_spawn_file_actions_addchdir_np(&fileActions, workDir)
             }
-        }
 
-        // Error handling
-        if chdirError != 0 || spawnAttributeError != 0 {
-            try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-            if spawnAttributeError != 0 {
+            // Error handling
+            if chdirError != 0 || spawnAttributeError != 0 {
+                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                if spawnAttributeError != 0 {
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: spawnAttributeError)
+                    )
+                }
+
+                if chdirError != 0 {
+                    throw SubprocessError(
+                        code: .init(.spawnFailed),
+                        underlyingError: .init(rawValue: spawnAttributeError)
+                    )
+                }
+            }
+            // Run additional config
+            if let spawnConfig = self.platformOptions.preSpawnProcessConfigurator {
+                try spawnConfig(&spawnAttributes, &fileActions)
+            }
+
+            // Spawn
+            let spawnError: CInt = possibleExecutablePath.withCString { exePath in
+                return supplementaryGroups.withOptionalUnsafeBufferPointer { sgroups in
+                    return _subprocess_spawn(
+                        &pid,
+                        exePath,
+                        &fileActions,
+                        &spawnAttributes,
+                        argv,
+                        env,
+                        uidPtr,
+                        gidPtr,
+                        Int32(supplementaryGroups?.count ?? 0),
+                        sgroups?.baseAddress,
+                        self.platformOptions.createSession ? 1 : 0
+                    )
+                }
+            }
+            // Spawn error
+            if spawnError != 0 {
+                if spawnError == ENOENT {
+                    // Move on to another possible path
+                    continue
+                }
+                // Throw all other errors
+                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                 throw SubprocessError(
                     code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: spawnAttributeError)
+                    underlyingError: .init(rawValue: spawnError)
                 )
             }
-
-            if chdirError != 0 {
-                throw SubprocessError(
-                    code: .init(.spawnFailed),
-                    underlyingError: .init(rawValue: spawnAttributeError)
-                )
-            }
-        }
-        // Run additional config
-        if let spawnConfig = self.platformOptions.preSpawnProcessConfigurator {
-            try spawnConfig(&spawnAttributes, &fileActions)
-        }
-        // Spawn
-        var pid: pid_t = 0
-        let spawnError: CInt = executablePath.withCString { exePath in
-            return supplementaryGroups.withOptionalUnsafeBufferPointer { sgroups in
-                return _subprocess_spawn(
-                    &pid,
-                    exePath,
-                    &fileActions,
-                    &spawnAttributes,
-                    argv,
-                    env,
-                    uidPtr,
-                    gidPtr,
-                    Int32(supplementaryGroups?.count ?? 0),
-                    sgroups?.baseAddress,
-                    self.platformOptions.createSession ? 1 : 0
-                )
-            }
-        }
-        // Spawn error
-        if spawnError != 0 {
-            try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
-            throw SubprocessError(
-                code: .init(.spawnFailed),
-                underlyingError: .init(rawValue: spawnError)
+            return Execution(
+                processIdentifier: .init(value: pid),
+                output: output,
+                error: error,
+                outputPipe: outputPipe,
+                errorPipe: errorPipe
             )
         }
-        return Execution(
-            processIdentifier: .init(value: pid),
-            output: output,
-            error: error,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe
+
+        // If we reach this point, it means either the executable path
+        // or working directory is not valid. Since posix_spawn does not
+        // provide which one is not valid, here we make a best effort guess
+        // by checking whether the working directory is valid. This technically
+        // still causes TOUTOC issue, but it's the best we can do for error recovery.
+        try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+        let workingDirectory = self.workingDirectory.string
+        guard Configuration.pathAccessible(workingDirectory, mode: F_OK) else {
+            throw SubprocessError(
+                code: .init(.failedToChangeWorkingDirectory(workingDirectory)),
+                underlyingError: .init(rawValue: ENOENT)
+            )
+        }
+        throw SubprocessError(
+            code: .init(.executableNotFound(self.executable.description)),
+            underlyingError: .init(rawValue: ENOENT)
         )
     }
 }

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -144,7 +144,6 @@ extension Configuration {
         error: Error,
         errorPipe: CreatedPipe
     ) throws -> Execution<Output, Error> {
-
         // Instead of checking if every possible executable path
         // is valid, spawn each directly and catch ENOENT
         let possiblePaths = self.executable.possibleExecutablePaths(
@@ -327,7 +326,11 @@ extension Configuration {
                     continue
                 }
                 // Throw all other errors
-                try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
+                try self.cleanupPreSpawn(
+                    input: inputPipe,
+                    output: outputPipe,
+                    error: errorPipe
+                )
                 throw SubprocessError(
                     code: .init(.spawnFailed),
                     underlyingError: .init(rawValue: spawnError)

--- a/Tests/SubprocessTests/SubprocessTests+Unix.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Unix.swift
@@ -96,17 +96,14 @@ extension SubprocessUnixTests {
             return
         }
         do {
-            // Since we are using the path directly,
-            // we expect the error to be thrown by the underlying
-            // posix_spawn
             _ = try await Subprocess.run(.path("/usr/bin/do-not-exist"))
-            Issue.record("Expected to throw POSIXError")
+            Issue.record("Expected to throw SubprocessError")
         } catch {
             guard let subprocessError: SubprocessError = error as? SubprocessError else {
-                Issue.record("Expected POSIXError, got \(error)")
+                Issue.record("Expected SubprocessError, got \(error)")
                 return
             }
-            #expect(subprocessError.code == .init(.spawnFailed))
+            #expect(subprocessError.code == .init(.executableNotFound("/usr/bin/do-not-exist")))
         }
     }
 }


### PR DESCRIPTION
This PR addresses two TOCTOU issues in Subprocess:
1. Instead of checking whether the executable path is accessible before spawning, spawn directly and catch for `ENOENT`.
2. Instead of checking whether working directory changes before setting, unconditionally set it.

While I was here, also fixed issues with fork/exec implementation such that the child process is not properly terminated and does not forward the exec failure code to parent.

Resolves: https://github.com/iCharlesHu/Subprocess/issues/54, https://github.com/iCharlesHu/Subprocess/issues/52,  https://github.com/iCharlesHu/Subprocess/issues/42, https://github.com/iCharlesHu/Subprocess/issues/43