### PR TITLE
Bad pointer dereference on Linux

### DIFF
--- a/Tests/SubprocessTests/StressTests.swift
+++ b/Tests/SubprocessTests/StressTests.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Subprocess
+
+@Suite
+struct SubprocessTests {
+    @Test
+    func manySubprocesses() async throws {
+        for _ in 0..<1000 {
+            let output = try await run(
+                .path(.init("/bin/echo")),
+                arguments: ["Hello, world!"],
+            )
+            #expect(output.standardOutput == "Hello, world!\n")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a test that fails on Linux. On macOS this can be reproduced by running:

```shell
docker run --rm -v $(pwd):/code -w /code swift:6.1 swift test
```

I would expect this test to pass, but instead I get the following failure. This is reproducible on both Swift 6.1 and 6.0.

```
*** Signal 11: Backtracing from 0xffff8d4ccdf0... done ***

*** Program crashed: Bad pointer dereference at 0x0000000000000050 ***

Thread 0:

0  0x0000ffff8dad43f4 initializeBufferWithCopyOfBuffer for Range in libswiftCore.so

Thread 1 crashed:

0      0x0000ffff8d4ccdf0 _dispatch_event_loop_drain + 1216 in libdispatch.so
1 [ra] 0x0000ffff8d4c1e38 _dispatch_mgr_invoke + 123 in libdispatch.so
2 [ra] 0x0000ffff8d4c1dac _dispatch_mgr_thread + 131 in libdispatch.so
3 [ra] 0x0000ffff8d4c5118 _dispatch_worker_thread + 431 in libdispatch.so
4 [ra] 0x0000ffff8c27595c <unknown> in libc.so.6

Thread 2:

0  0x0000ffff78022900


Registers:

 x0 0x0000000000000001  1
 x1 0x0000000000000081  129
 x2 0x0000000000000001  1
 x3 0x0000000000000000  0
 x4 0x0000000000000000  0
 x5 0x0000000000000008  8
 x6 0x0000000000000000  0
 x7 0x0000000000000004  4
 x8 0x0000000000000062  98
 x9 0x001ffe1c80000000  9005122638053376
x10 0x001ffe1c80000000  9005122638053376
x11 0x00007ff840000000  140704202358784
x12 0x0000000000000000  0
x13 0x0000000000000000  0
x14 0x000006cb6e4c0bf9  7470798605305
x15 0x0000000029aacefe  699059966
x16 0x0000000000000001  1
x17 0x0000ffff8c27da50  fd 7b bd a9 fd 03 00 91 f3 53 01 a9 f4 03 00 aa  ý{½©ý···óS·©ô··ª
x18 0x000000000000001d  29
x19 0x00000000ffffffff  4294967295
x20 0x0000000000000030  48
x21 0x0000000000000000  0
x22 0x0000000000000000  0
x23 0x0000000000000003  3
x24 0x0000ffff8d502000  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ················
x25 0x0000ffff60000e20  80 4a f6 a3 f0 ff 00 00 e3 2d ad 22 f3 4b b6 bc  ·Jö£ðÿ··ã-"óK¶¼
x26 0x0000ffff8d502640  20 00 00 00 03 00 00 01 d0 23 00 84 ff ff 00 00   ·······Ð#··ÿÿ··
x27 0x0000000000000010  16
x28 0x000000007fffffff  2147483647
 fp 0x0000ffff892ee670  10 e7 2e 89 ff ff 00 00 38 1e 4c 8d ff ff 00 00  ·ç.·ÿÿ··8·L·ÿÿ··
 lr 0x0000ffff8d4ccde0  f4 03 15 aa 15 fd ff b5 34 0f 40 f9 54 03 00 b4  ô··ª·ýÿµ4·@ùT··´
 sp 0x0000ffff892ee4e0  00 00 00 00 00 00 00 00 10 0error: Exited with unexpected signal code 11
0 00 00 00 00 00 00  ················
 pc 0x0000ffff8d4ccdf0  88 12 40 f9 95 02 40 f9 e8 03 28 aa 09 09 40 b9  ··@ù··@ùè·(ª··@¹


Images (19 omitted):

0x0000ffff8c1f0000–0x0000ffff8c389d89 1d7249a4f207d07166ff4be43acdc68a01faaa04 libc.so.6       /usr/lib/aarch64-linux-gnu/libc.so.6
0x0000ffff8d490000–0x0000ffff8d4dabb0 9d3be99ac1bfeac7bf6ad9c09ff973dd15567c4e libdispatch.so  /usr/lib/swift/linux/libdispatch.so
0x0000ffff8d840000–0x0000ffff8dd639f8 4054809a682f19c7375e259658cfeb97ce01961e libswiftCore.so /usr/lib/swift/linux/libswiftCore.so

Backtrace took 0.01s
```