### PR TITLE
Here's a workaround around that bug i created

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
     traits: [
         "SubprocessFoundation",
         "SubprocessSpan",
+        "ContemporaryMacOS",
         .default(
             enabledTraits: defaultTraits
         ),

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -33,6 +33,9 @@ import System
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 public func run<
     Input: InputProtocol,
     Output: OutputProtocol,
@@ -122,6 +125,9 @@ public func run<
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 public func run<Result, Input: InputProtocol, Output: OutputProtocol, Error: OutputProtocol>(
     _ executable: Executable,
     arguments: Arguments = [],
@@ -163,6 +169,9 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol, Error: Out
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
     _ executable: Executable,
     arguments: Arguments = [],
@@ -196,6 +205,9 @@ public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
 /// - Returns a CollectedResult containing the result of the run.
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 public func run<
     Input: InputProtocol,
@@ -243,6 +255,9 @@ public func run<
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
     _ configuration: Configuration,
     output: Output,
@@ -274,6 +289,9 @@ public func run<Result, Output: OutputProtocol, Error: OutputProtocol>(
 /// - Returns: the process identifier for the subprocess.
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 public func runDetached(
     _ executable: Executable,
@@ -310,6 +328,9 @@ public func runDetached(
 /// - Returns: the process identifier for the subprocess.
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 public func runDetached(
     _ configuration: Configuration,

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -61,6 +61,9 @@ public struct Configuration: Sendable {
     #if SubprocessSpan
     @available(SubprocessSpan, *)
     #endif
+    #if ContemporaryMacOS
+    @available(macOS 15, *)
+    #endif
     internal func run<
         Result,
         Output: OutputProtocol,
@@ -230,6 +233,9 @@ public struct Configuration: Sendable {
     #if SubprocessSpan
     @available(SubprocessSpan, *)
     #endif
+    #if ContemporaryMacOS
+    @available(macOS 15, *)
+    #endif
     internal func run<
         Result,
         Input: InputProtocol,
@@ -344,6 +350,9 @@ extension Configuration {
     @Sendable
     #if SubprocessSpan
     @available(SubprocessSpan, *)
+    #endif
+    #if ContemporaryMacOS
+    @available(macOS 15, *)
     #endif
     private func cleanup<
         Output: OutputProtocol,

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -37,6 +37,9 @@ import Synchronization
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 public final class Execution<
     Output: OutputProtocol,
     Error: OutputProtocol
@@ -101,6 +104,9 @@ public final class Execution<
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 extension Execution where Output == SequenceOutput {
     /// The standard output of the subprocess.
     ///
@@ -123,6 +129,9 @@ extension Execution where Output == SequenceOutput {
 
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 extension Execution where Error == SequenceOutput {
     /// The standard error of the subprocess.
@@ -170,6 +179,9 @@ internal typealias CapturedIOs<
 
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 extension Execution {
     internal func captureIOs() async throws -> CapturedIOs<

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -156,6 +156,9 @@ extension Configuration {
     #if SubprocessSpan
     @available(SubprocessSpan, *)
     #endif
+    #if ContemporaryMacOS
+    @available(macOS 15, *)
+    #endif
     internal func spawn<
         Output: OutputProtocol,
         Error: OutputProtocol

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -111,6 +111,9 @@ extension ProcessIdentifier: CustomStringConvertible, CustomDebugStringConvertib
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 extension Execution {
     /// Send the given signal to the child process.
     /// - Parameters:

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -76,6 +76,9 @@ public struct TeardownStep: Sendable, Hashable {
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
+#endif
 extension Execution {
     /// Performs a sequence of teardown steps on the Subprocess.
     /// Teardown sequence always ends with a `.kill` signal
@@ -95,6 +98,9 @@ internal enum TeardownStepCompletion {
 
 #if SubprocessSpan
 @available(SubprocessSpan, *)
+#endif
+#if ContemporaryMacOS
+@available(macOS 15, *)
 #endif
 extension Execution {
     internal func gracefulShutDown(


### PR DESCRIPTION
Added package Trait `ContemporaryMacOS` which acts as marker for propagating `@available(macOS 15, *)` allowing to evade bumping package version to macOS 15 and instead supplying this Trait when depending on Subprocess package and hiding things which cascade the `Atomic` & `AsyncSequence<Result, Failure>` requirement for macOS 15.

@iCharlesHu let me know what you think about this.